### PR TITLE
Made build.sh a bit more rescilient

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,15 @@
 #!/bin/sh
 
+OS=`sw_vers  -productVersion | cut -f 1,2 -d "." `
 CC=clang
+if [[ -z "$JAVA_HOME" ]]; then 
+	JAVA_HOME=`/usr/libexec/java_home`
+fi
 INCLUDE="-I ${JAVA_HOME}/include -I ${JAVA_HOME}/include/darwin"
 FRAMEWORK="-framework Cocoa"
 SRC="native/main.m"
 DST="src/main/resources/io/github/appbundler/JavaAppLauncher"
-SDK="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk"
+SDK="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX$OS.sdk"
 ARCH="x86_64"
 MIN_MAC_OSX_VERSION="10.7"
 


### PR DESCRIPTION
I modified the build.sh script to do the following:
- Determine the OS X version rather than assume we're building on 10.8, so one can now build on 10.8 or 10.9.
- Added detection for an unset JAVA_HOME variable, and setting JAVA_HOME if it is missing.

Thanks for an awesome plugin. 
