### PR TITLE
Added -Xdock:name to the vmOptions to set About and Quit menu names

### DIFF
--- a/src/main/resources/sh/tak/appbundler/Info.plist.template
+++ b/src/main/resources/sh/tak/appbundler/Info.plist.template
@@ -37,6 +37,7 @@
     <key>JVMOptions</key>
     <array>
       <string>-Dapple.laf.useScreenMenuBar=true</string>
+      <string>-Xdock:name=${bundleName}</string>
     </array>
     <key>JVMArguments</key>
     <array/>


### PR DESCRIPTION
For the bundle name to be used for the application in the About menu and Quit menu, it needs to be passed to the VM as such:

```bash
-Xdock:name=My App Name 
```

I've modified the Info.plist template to do this. 