### PR TITLE
Added the ability for DMG files to be created on linux via the genisoimage command.

### DIFF
--- a/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
+++ b/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
@@ -174,6 +174,8 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
      * will be internet-enabled. <br/><br/>
      * The default is ${false}. This property depends on the
      * <code>generateDiskImageFile</code> property.
+     * 
+     * This feature can only be executed in Mac OS X environments.
      *
      * @parameter default-value="false"
      */
@@ -181,7 +183,7 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
 
     /**
      * Tells whether to generate the disk image (.dmg) file or not. <br/><br/>
-     * This feature can only be executed in Mac OS X environments.
+     * This feature can only be executed in Mac OS X and Linux environments.
      *
      * @parameter default-value="false"
      */
@@ -424,8 +426,35 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
                     }
                 }
                 projectHelper.attachArtifact(project, "dmg", null, diskImageFile);
-            } else {
-                getLog().warn("Disk Image file cannot be generated in non Mac OS X environments");
+            } 
+            if (SystemUtils.IS_OS_LINUX) {
+				getLog().info("Generating the Disk Image file");
+				Commandline linux_dmg = new Commandline();
+				try {
+					linux_dmg.setExecutable("genisoimage");
+					linux_dmg.createArgument().setValue("-V");
+					linux_dmg.createArgument().setValue(bundleName);
+					linux_dmg.createArgument().setValue("-D");
+					linux_dmg.createArgument().setValue("-R");
+					linux_dmg.createArgument().setValue("-apple");
+					linux_dmg.createArgument().setValue("-no-pad");
+					linux_dmg.createArgument().setValue("-o");
+					linux_dmg.createArgument().setValue(diskImageFile.getAbsolutePath());
+					linux_dmg.createArgument().setValue(buildDirectory.getAbsolutePath());
+
+					try {
+						linux_dmg.execute().waitFor();
+					} catch (InterruptedException ex) {
+						throw new MojoExecutionException("Thread was interrupted while creating DMG " + diskImageFile,
+								ex);
+					}
+				} catch (CommandLineException ex) {
+					throw new MojoExecutionException("Error creating disk image " + diskImageFile + " genisoimage probably missing", ex);
+				}
+				projectHelper.attachArtifact(project, "dmg", null, diskImageFile);
+
+			} else {
+                getLog().warn("Disk Image file cannot be generated in non Mac OS X and Linux environments");
             }
         }
 


### PR DESCRIPTION
Linux distros have access to either the genisoimage command.  I'm not familiar with internet enabled DMG's so I didn't research that capability and it isn't added if the system detects Linux.  As is stands the plugin does generate a valid DMG file in linux that I have used with my projects. Here information on the command.

genisoimage(from cdrkit): Creates a readonly .dmg file from a directory

genisoimage -D -V "%lt;Volume Label>" -no-pad -r -apple -o <file.dmg> <Source Directory>

-D: Do not use deep directory relocation, and instead just pack them in the way we see them
-V: Volume Label
-no-pad: Do not pad the end by 150 sectors (300kb). As it is not a cd image, not required
-apple -r: Creates a .dmg image