### PR TITLE
Bug when executing external process from Java application

### DIFF
--- a/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
+++ b/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
@@ -321,38 +321,28 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
         }
 
         // 5. Check if JRE should be embedded. Check JRE path. Copy JRE
-        if (jrePath != null) {
-            getLog().info("Copying the JRE Folder " + jrePath);
-
+        if (jrePath != null) {            
             File f = new File(jrePath);
             if (f.exists() && f.isDirectory()) {
                 // Check if the source folder is a jdk-home
-                File pluginsDirectory = new File(contentsDir, "PlugIns/JRE");
+                File pluginsDirectory = new File(contentsDir, "PlugIns/JRE/Contents/Home/jre");
                 pluginsDirectory.mkdirs();
+                
+                File sourceFolder = new File(jrePath, "Contents/Home");                
+                if (new File(jrePath, "Contents/Home/jre").exists()) {
+                    sourceFolder = new File(jrePath, "Contents/Home/jre");
+                }
+                
                 try {
-                    FileUtils.copyDirectoryStructure(f, pluginsDirectory);
-                    File binFolder = new File(pluginsDirectory, "Contents/Home/bin");
+                    getLog().info("Copying the JRE Folder from : [" + sourceFolder + "] to PlugIn folder: [" + pluginsDirectory + "]");
+                    FileUtils.copyDirectoryStructure(sourceFolder, pluginsDirectory);
+                    File binFolder = new File(pluginsDirectory, "bin");
                     //Setting execute permissions on executables in JRE
                     for (String filename : binFolder.list()) {
                         new File(binFolder, filename).setExecutable(true, false);
                     }
-                    // creating fake folder if a JRE is used
-                    File jdkDylibFolder = new File(jrePath, "Contents/Home/jre/lib/jli/libjli.dylib");
-                    if (!jdkDylibFolder.exists()) {
-                        getLog().info("Assuming that this is a JRE creating fake folder");
-                        File fakeJdkFolder = new File(pluginsDirectory, "Contents/Home/jre/lib");
-                        fakeJdkFolder.mkdirs();
-                        FileUtils.copyDirectoryStructure(new File(pluginsDirectory, "Contents/Home/lib"), fakeJdkFolder);
-
-                        fakeJdkFolder = new File(pluginsDirectory, "Contents/Home/jre/bin");
-                        fakeJdkFolder.mkdirs();
-                        FileUtils.copyDirectoryStructure(new File(pluginsDirectory, "Contents/Home/bin"), fakeJdkFolder);
-
-                        FileUtils.deleteDirectory(new File(pluginsDirectory, "Contents/Home/bin"));
-                        FileUtils.deleteDirectory(new File(pluginsDirectory, "Contents/Home/lib"));
-                    }
-                    
-                    new File (pluginsDirectory, "Contents/Home/jre/lib/jspawnhelper").setExecutable(true,false);
+                                       
+                    new File (pluginsDirectory, "lib/jspawnhelper").setExecutable(true,false);
                     embeddJre = true;
                 } catch (IOException ex) {
                     throw new MojoExecutionException("Error copying folder " + f + " to " + pluginsDirectory, ex);

--- a/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
+++ b/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
@@ -666,7 +666,6 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
     private List<String> copyResources(File targetDirectory, List<FileSet> fileSets) throws MojoExecutionException {
         ArrayList<String> addedFiles = new ArrayList<String>();
         for (FileSet fileSet : fileSets) {
-
             // Get the absolute base directory for the FileSet
             File sourceDirectory = new File(fileSet.getDirectory());
 
@@ -694,6 +693,8 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
 
                 try {
                     FileUtils.copyFile(source, destinationFile);
+                    destinationFile.setExecutable(fileSet.isExecutable(),false);
+                    
                 } catch (IOException e) {
                     throw new MojoExecutionException("Error copying additional resource " + source, e);
                 }

--- a/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
+++ b/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
@@ -326,6 +326,7 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
 
             File f = new File(jrePath);
             if (f.exists() && f.isDirectory()) {
+                // Check if the source folder is a jdk-home
                 File pluginsDirectory = new File(contentsDir, "PlugIns/JRE");
                 pluginsDirectory.mkdirs();
                 try {
@@ -336,7 +337,7 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
                         new File(binFolder, filename).setExecutable(true, false);
                     }
                     // creating fake folder if a JRE is used
-                    File jdkDylibFolder = new File(pluginsDirectory, "Contents/Home/jre/lib/jli/libjli.dylib");
+                    File jdkDylibFolder = new File(jrePath, "Contents/Home/jre/jli/libjli.dylib");
                     if (!jdkDylibFolder.exists()) {
                         getLog().info("Assuming that this is a JRE creating fake folder");
                         File fakeJdkFolder = new File(pluginsDirectory, "Contents/Home/jre/lib");
@@ -352,7 +353,6 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
                     }
                     
                     new File (pluginsDirectory, "Contents/Home/jre/lib/jspawnhelper").setExecutable(true,false);
-                    getLog().info(new File (pluginsDirectory, "Contents/Home/jre/lib/jspawnhelper").getAbsolutePath());
                     embeddJre = true;
                 } catch (IOException ex) {
                     throw new MojoExecutionException("Error copying folder " + f + " to " + pluginsDirectory, ex);

--- a/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
+++ b/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
@@ -350,6 +350,9 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
                         FileUtils.deleteDirectory(new File(pluginsDirectory, "Contents/Home/bin"));
                         FileUtils.deleteDirectory(new File(pluginsDirectory, "Contents/Home/lib"));
                     }
+                    
+                    new File (pluginsDirectory, "Contents/Home/jre/lib/jspawnhelper").setExecutable(true,false);
+                    getLog().info(new File (pluginsDirectory, "Contents/Home/jre/lib/jspawnhelper").getAbsolutePath());
                     embeddJre = true;
                 } catch (IOException ex) {
                     throw new MojoExecutionException("Error copying folder " + f + " to " + pluginsDirectory, ex);

--- a/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
+++ b/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
@@ -337,7 +337,7 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
                         new File(binFolder, filename).setExecutable(true, false);
                     }
                     // creating fake folder if a JRE is used
-                    File jdkDylibFolder = new File(jrePath, "Contents/Home/jre/jli/libjli.dylib");
+                    File jdkDylibFolder = new File(jrePath, "Contents/Home/jre/lib/jli/libjli.dylib");
                     if (!jdkDylibFolder.exists()) {
                         getLog().info("Assuming that this is a JRE creating fake folder");
                         File fakeJdkFolder = new File(pluginsDirectory, "Contents/Home/jre/lib");

--- a/src/main/java/sh/tak/appbundler/FileSet.java
+++ b/src/main/java/sh/tak/appbundler/FileSet.java
@@ -22,7 +22,7 @@ package sh.tak.appbundler;
  * <p/>
  * Created date: Jan 19, 2008
  *
- * @author Zhenya Nyden
+ * @author Zhenya Nyden, Schwarmi Bamamoto
  */
 public class FileSet extends org.apache.maven.model.FileSet {
 
@@ -33,6 +33,11 @@ public class FileSet extends org.apache.maven.model.FileSet {
      * @parameter expression="true"
      */
     private boolean useDefaultExcludes;
+    
+    /**
+     * @parameter expression="false"
+     */
+    private boolean executable;
 
     /**
      * Getter for the useDefaultExcludes property.
@@ -55,6 +60,28 @@ public class FileSet extends org.apache.maven.model.FileSet {
      */
     public void setUseDefaultExcludes( boolean useDefaultExcludes ) {
         this.useDefaultExcludes = useDefaultExcludes;
+    }
+
+    /**
+     * Getter for the executbale property.
+     * Return true if the should be executable. The flag is for file management
+     * method calls that should be aware of setting the execute flag after 
+     * copying or moving.
+     * @return the executable
+     */
+    public boolean isExecutable() {
+        return executable;
+    }
+
+    /**
+     * Setter for execute property.
+     * Setting this the execute property to true means that the execute flag 
+     * of this file should be set. This is userfull for helper applilactions that
+     * are included in the .dmg file.
+     * @param executable the executable to set
+     */
+    public void setExecutable(boolean executable) {
+        this.executable = executable;
     }
 
 }


### PR DESCRIPTION
These commits fixing two bugs. 
The first bug was impossibility to run an external process from the Java application in the .dmg file. This was caused by a missing executable flag for a helper application named jspwanhelper.
The other fixes the JRE detection which was buggy. This leads to duplicate JRE files in the .dmg file.