### PR TITLE
Add capability to use a shared jre between multiple applications by setting jreFullPath in configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /*.iml
 /target
 /src/main/resources/sh/tak/appbundler/JavaAppLauncher
+.settings/

--- a/native/main.m
+++ b/native/main.m
@@ -32,6 +32,7 @@
 #define JAVA_LAUNCH_ERROR "JavaLaunchError"
 
 #define JVM_RUNTIME_KEY "JVMRuntime"
+#define JVM_RUNTIME_PATH_KEY "JVMRuntimePath"
 #define JVM_MAIN_CLASS_NAME_KEY "JVMMainClassName"
 #define JVM_CLASS_PATHS_KEY "JVMClassPaths"
 #define JVM_OPTIONS_KEY "JVMOptions"
@@ -104,11 +105,16 @@ int launch(char *commandName) {
 
     // Locate the JLI_Launch() function
     NSString *runtime = [infoDictionary objectForKey:@JVM_RUNTIME_KEY];
+    NSString *runtimeFullPath = [infoDictionary objectForKey:@JVM_RUNTIME_PATH_KEY];
 
     const char *libjliPath = NULL;
     if (runtime != nil && [runtime length] > 0) {
         NSString *runtimePath = [[[NSBundle mainBundle] builtInPlugInsPath] stringByAppendingPathComponent:runtime];
         libjliPath = [[runtimePath stringByAppendingPathComponent:@"Contents/Home/jre/lib/jli/libjli.dylib"] fileSystemRepresentation];
+    }else if (runtimeFullPath != nil && [runtimeFullPath length] > 0 ) {
+        //If path has $USER, replace it with currently logged in user's username for home directory 
+        runtimeFullPath = [runtimeFullPath stringByReplacingOccurrencesOfString:@"$USER" withString:NSUserName()];    
+        libjliPath = [[runtimeFullPath stringByAppendingPathComponent:@"Contents/Home/jre/lib/jli/libjli.dylib"] fileSystemRepresentation];
     } else {
         libjliPath = LIBJLI_DYLIB;
     }

--- a/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
+++ b/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
@@ -265,6 +265,13 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
     private String jrePath;
 
     /**
+     * The full path to the installation directory of the jre on the user's machine.
+     *
+     * @parameter default-value=""
+     */
+    private String jreFullPath;
+
+    /**
      * Bundle project as a Mac OS X application bundle.
      *
      * @throws MojoExecutionException If an unexpected error occurs during
@@ -363,6 +370,9 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
             } else {
                 getLog().warn("JRE not found check jrePath setting in pom.xml");
             }
+        }else if (jreFullPath != null){
+            getLog().info("JRE Full path is used [" + jreFullPath + "]");
+            embeddJre = true;
         }
 
         // 6. Create and write the Info.plist file
@@ -584,10 +594,15 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
         velocityContext.put("bundleName", cleanBundleName(bundleName));
         velocityContext.put("workingDirectory", workingDirectory);
 
-        if (embeddJre) {
+        if (embeddJre && jrePath != null) {
             velocityContext.put("jrePath", "JRE");
+            velocityContext.put("jreFullPath", "");
+        } else if (embeddJre && jreFullPath != null) {
+            velocityContext.put("jrePath", "");
+            velocityContext.put("jreFullPath", jreFullPath);
         } else {
             velocityContext.put("jrePath", "");
+            velocityContext.put("jreFullPath", "");
         }
 
         if (iconFile == null) {

--- a/src/main/resources/sh/tak/appbundler/Info.plist.template
+++ b/src/main/resources/sh/tak/appbundler/Info.plist.template
@@ -32,6 +32,8 @@
     <true/>
     <key>JVMRuntime</key>
     <string>${jrePath}</string>
+    <key>JVMRuntimePath</key>
+    <string>${jreFullPath}</string>
     <key>JVMMainClassName</key>
     <string>${mainClass}</string>
     <key>JVMClassPaths</key>


### PR DESCRIPTION
Hi. I had a problem where we have 3 java appbundles and only one has a bundled jre. In order to reduce the size of the installer, I had to make the other two use the existing jre installation. This pull request adds the capability to set a jre full path to be used by the bundled application.