### PR TITLE
Changed from MAC OSX to MAC

### DIFF
--- a/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
+++ b/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
@@ -405,7 +405,7 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
 
         // 8. Create the DMG file
         if (generateDiskImageFile) {
-            if (SystemUtils.IS_OS_MAC_OSX) {
+            if (SystemUtils.IS_OS_MAC) {
                 getLog().info("Generating the Disk Image file");
                 Commandline dmg = new Commandline();
                 try {


### PR DESCRIPTION
OS is now called macOS, IS_OS_MAC_OSX returns false in Sierra +