### PR TITLE
added option to set disk image file system

### DIFF
--- a/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
+++ b/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
@@ -190,6 +190,15 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
     private boolean generateDiskImageFile;
 
     /**
+     * The file system for the disk image. <br/><br/>
+     * The default is HFS+. This property depends on the
+     * <code>generateDiskImageFile</code> property.
+     *
+     * @parameter default-value="HFS+"
+     */
+    private String fileSystem;
+
+    /**
      * Tells whether to include a symbolic link to the generated disk image (.dmg) file or not. <br/><br/>
      * Relevant only if generateDiskImageFile is set.
      *
@@ -415,6 +424,8 @@ public class CreateApplicationBundleMojo extends AbstractMojo {
                     }
                     dmg.setExecutable("hdiutil");
                     dmg.createArgument().setValue("create");
+                    dmg.createArgument().setValue("-fs");
+                    dmg.createArgument().setValue(fileSystem);
                     dmg.createArgument().setValue("-srcfolder");
                     dmg.createArgument().setValue(buildDirectory.getAbsolutePath());
                     dmg.createArgument().setValue(diskImageFile.getAbsolutePath());


### PR DESCRIPTION
On macOS 10.13 the default file system used by hdiutil is now APFS. So disk images created on this version can't be opened on versions prior to 10.13. This PR adds an option to set the file system and restores the default to HFS+ (which it was before 10.13)