### PR TITLE
fix compatibility issue with Java 11

### DIFF
--- a/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
+++ b/src/main/java/sh/tak/appbundler/CreateApplicationBundleMojo.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.xml.stream.XMLInputFactory;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;


### PR DESCRIPTION
I got the following exception when running version 1.2.0 using OpenJDK 11.0.2 on MacOS 10.14:

```
Caused by: java.lang.NumberFormatException: multiple points
    at jdk.internal.math.FloatingDecimal.readJavaFormatString (FloatingDecimal.java:1914)
    at jdk.internal.math.FloatingDecimal.parseFloat (FloatingDecimal.java:122)
    at java.lang.Float.parseFloat (Float.java:455)
    at org.apache.commons.lang.SystemUtils.getJavaVersionAsFloat (SystemUtils.java:1117)
    at org.apache.commons.lang.SystemUtils.<clinit> (SystemUtils.java:817)
    at sh.tak.appbundler.CreateApplicationBundleMojo.execute (CreateApplicationBundleMojo.java:390)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
```

Looks like this error has been fixed in commons-lang 3.x.